### PR TITLE
Allow for ESP8266

### DIFF
--- a/src/ssd1306_i2c.c
+++ b/src/ssd1306_i2c.c
@@ -54,7 +54,9 @@ struct mgos_ssd1306 *mgos_ssd1306_create (const struct mgos_config_ssd1306 *cfg)
     if (i2c_cfg == NULL)
       return NULL;
     i2c_cfg->enable = cfg->i2c.enable;
+#ifndef I2C_NO_UNIT_NO
     i2c_cfg->unit_no = cfg->i2c.unit_no;
+#endif
     i2c_cfg->freq = cfg->i2c.freq;
     i2c_cfg->debug = cfg->i2c.debug;
     i2c_cfg->scl_gpio = cfg->i2c.scl_gpio;


### PR DESCRIPTION
Exclude ESP32 portion of code which fails on ESP8266