### PR TITLE
remove overly verbose logging statement

### DIFF
--- a/src/ssd1306_i2c.c
+++ b/src/ssd1306_i2c.c
@@ -524,7 +524,6 @@ mgos_ssd1306_draw_char (struct mgos_ssd1306 *oled, uint8_t x, uint8_t y, unsigne
   if (oled->font == NULL)
     return 0;
 
-  LOG (LL_INFO, ("Drawing %c at %d,%d", c, x, y));
   // we always have space in the font set
   if ((c < oled->font->char_start) || (c > oled->font->char_end))
     c = ' ';


### PR DESCRIPTION
When displaying text there would be a logging statement on
loglevel "INFO" for every character in the text. This is
too much detail for this loglevel. It might be fine for
"TRACE" if it is really needed.

This patch removes the logging statement.