### PR TITLE
Make string char pointers const

### DIFF
--- a/include/ssd1306.h
+++ b/include/ssd1306.h
@@ -241,7 +241,7 @@ extern "C"
    *
    * @return String witdth in pixels.
    */
-  uint8_t mgos_ssd1306_draw_string_color (struct mgos_ssd1306 *oled, uint8_t x, uint8_t y, char *str,
+  uint8_t mgos_ssd1306_draw_string_color (struct mgos_ssd1306 *oled, uint8_t x, uint8_t y, const char *str,
                                           mgos_ssd1306_color_t foreground, mgos_ssd1306_color_t background);
 
   /**
@@ -254,7 +254,7 @@ extern "C"
    *
    * @return String width in pixels.
    */
-  uint8_t mgos_ssd1306_draw_string (struct mgos_ssd1306 *oled, uint8_t x, uint8_t y, char *str);
+  uint8_t mgos_ssd1306_draw_string (struct mgos_ssd1306 *oled, uint8_t x, uint8_t y, const char *str);
 
   /**
    * @brief Measure on-screen width of string if drawn using active font.
@@ -264,7 +264,7 @@ extern "C"
    *
    * @return String width in pixels.
    */
-  uint8_t mgos_ssd1306_measure_string (struct mgos_ssd1306 *oled, char *str);
+  uint8_t mgos_ssd1306_measure_string (struct mgos_ssd1306 *oled, const char *str);
 
   /**
    * @brief Get the height of the active font.

--- a/src/ssd1306_i2c.c
+++ b/src/ssd1306_i2c.c
@@ -553,8 +553,8 @@ uint8_t mgos_ssd1306_draw_char (struct mgos_ssd1306 *oled, uint8_t x, uint8_t y,
   return (oled->font->char_descriptors[c].width);
 }
 
-uint8_t
-mgos_ssd1306_draw_string_color (struct mgos_ssd1306 * oled, uint8_t x, uint8_t y, char *str, mgos_ssd1306_color_t foreground, mgos_ssd1306_color_t background) {
+uint8_t mgos_ssd1306_draw_string_color (struct mgos_ssd1306 * oled, uint8_t x, uint8_t y, const char *str,
+                                        mgos_ssd1306_color_t foreground, mgos_ssd1306_color_t background) {
   uint8_t t = x;
 
   if (oled == NULL)
@@ -576,12 +576,12 @@ mgos_ssd1306_draw_string_color (struct mgos_ssd1306 * oled, uint8_t x, uint8_t y
   return (x - t);
 }
 
-uint8_t mgos_ssd1306_draw_string (struct mgos_ssd1306 * oled, uint8_t x, uint8_t y, char *str) {
+uint8_t mgos_ssd1306_draw_string (struct mgos_ssd1306 * oled, uint8_t x, uint8_t y, const char *str) {
   return mgos_ssd1306_draw_string_color (oled, x, y, str, SSD1306_COLOR_WHITE, SSD1306_COLOR_TRANSPARENT);
 }
 
 // return width of string
-uint8_t mgos_ssd1306_measure_string (struct mgos_ssd1306 * oled, char *str) {
+uint8_t mgos_ssd1306_measure_string (struct mgos_ssd1306 * oled, const char *str) {
   uint8_t w = 0;
   unsigned char c;
 


### PR DESCRIPTION
Non-const string constants get placed in RAM so `void foo(char *x); foo("bar");` will waste 4 bytes of RAM.