### PR TITLE
Improved support for smaller displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,18 @@ This driver should support displays of any resolution supported by the SSD1306.
 
 This driver does not yet support SPI operation.
 
+## Note about the [LOLIN / WEMOS OLED shield](https://wiki.wemos.cc/products:d1_mini_shields:oled_shield)
+
+It uses a 64x48 panel with column offset of 32, correct configuration for it is as follows:
+
+```yaml
+config_schema:
+  - ["i2c.enable", true]
+  - ["i2c.sda_gpio", 4]
+  - ["i2c.scl_gpio", 5]
+  - ["ssd1306.i2c.enable", false]  # Use system bus.
+  - ["ssd1306.enable", true]
+  - ["ssd1306.width", 64]
+  - ["ssd1306.height", 48]
+  - ["ssd1306.col_offset", 32]
+```

--- a/include/ssd1306.h
+++ b/include/ssd1306.h
@@ -1,24 +1,24 @@
 /**
  * Copyright 2018 Brandon Davidson <brad@oatmail.org>
  * copyright 2018 Manfred Mueller-Spaeth <fms1961@gmail.com> (changes, additions)
- *  
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
  * of the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR 
  * A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
  * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- * 
+ *
  **/
 
 #ifndef SSD1306_H
@@ -309,7 +309,7 @@ extern "C"
    * @param oled SSD1306 driver handle.
    * @param bool alt, if the current way won't work, try the second one
    */
-	void mgos_ssd1306_rotate_display (struct mgos_ssd1306 *oled, bool alt);
+  void mgos_ssd1306_rotate_display (struct mgos_ssd1306 *oled, bool alt);
 
   /**
    * @brief Copy pre-rendered bytes directly into the bitmap.
@@ -330,8 +330,8 @@ extern "C"
   /**
    * @brief Start the displays functionality
    */
-	void mgos_ssd1306_start (struct mgos_ssd1306 *oled);
-	
+  void mgos_ssd1306_start (struct mgos_ssd1306 *oled);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/mos.yml
+++ b/mos.yml
@@ -19,6 +19,8 @@ config_schema:
   - ["ssd1306.width", "i", 128, {title: "Screen width"}]
   - ["ssd1306.height", "i", 64, {title: "Screen height"}]
   - ["ssd1306.address", "i", 0x3c, {title: "Screen controller I2C address"}]
+  - ["ssd1306.col_offset", "i", 0, {title: "Screen column offset; some smaller screens need this"}]
+  - ["ssd1306.com_pins", "i", 0x12, {title: "Screen COM pins configuration, depends on physical attachemnt of the panel to the chip; 0x02, 0x12, 0x22 or 0x32 are valid values"}]
   - ["ssd1306.i2c", "o", {title: "SSD1306 I2C settings"}]
   - ["ssd1306.i2c.enable", "b", true, {title: "Enable SSD1306-specific I2C configuration"}]
   - ["ssd1306.i2c.freq", "i", 400000, {title: "Clock frequency"}]


### PR DESCRIPTION
 * Added column offset, required by [LOLIN / WEMOS OLED shield](https://wiki.wemos.cc/products:d1_mini_shields:oled_shield).
 * Made COM pins a config setting, it has nothing to do with the size of
   the display (< 64 or not), purely with the panel to chip attachment.
 * Some minor clean-ups (trailing spaces, tabs).

CL: ssd1306: Improved support for smaller displays