### PR TITLE
Removed mgos_ssd1306_init from the public interface.

### DIFF
--- a/include/ssd1306.h
+++ b/include/ssd1306.h
@@ -57,13 +57,6 @@ extern "C"
   } mgos_ssd1306_color_t;
 
   /**
-   * @brief Standard Mongoose-OS init hook.
-   *
-   * @return True if module was enabled and successfully initialized.
-   */
-  bool mgos_ssd1306_init (void);
-
-  /**
    * @brief Access the SSD1306 driver handle that is set up via sysconfig.
    *
    * @return Preconfigured SSD1306 driver handle.


### PR DESCRIPTION
mgos_ssd1306_init is a private library initialization function
called by the auto-generated MGOS startup code. This should not be
called by the user, so removing from the public interface.